### PR TITLE
fix: session.vim

### DIFF
--- a/pack/local/start/session/autoload/session/session.vim
+++ b/pack/local/start/session/autoload/session/session.vim
@@ -42,13 +42,21 @@ export class Session
 	enddef
 
 	static def Load(dir: string, sessionName: string, silent: bool)
-		var sname = sessionName ?? fnamemodify(getcwd(), ':t')
-		var sessions = All(dir)->filter((_, name) => name =~# $'\/{sname}\/')
+		if empty(sessionName)
+			if !silent
+				:redraw
+				log.Error($'Load Session error: sessionName is empty')
+			endif
+
+			return
+		endif
+
+		var sessions = All(dir)->filter((_, name) => name =~# $'\/{sessionName}\/')
 
 		if empty(sessions)
 			if !silent
 				:redraw
-				log.Error($'Load Session error: {sname} not found in {fnamemodify(dir, ':~:.')}')
+				log.Error($'Load Session error: {sessionName} not found in {fnamemodify(dir, ':~')}')
 			endif
 
 			return

--- a/pack/local/start/session/plugin/session.vim
+++ b/pack/local/start/session/plugin/session.vim
@@ -32,8 +32,19 @@ Command.new('SessionSave')
 			return
 		endif
 
+		if exists_compiled('+shellslash')
+			def Recover(saved: any)
+				&shellslash = saved
+			enddef
+
+			defer Recover(&shellslash)
+			&shellslash = true
+		endif
+
 		var dir = get(g:, "session_dir", "")
-		session.Session.Save(dir, fnamemodify(getcwd(), ':t'), attr.mods.silent)
+		var sessionName = substitute(getcwd(), '\v(^[A-Z]):', '\1@', '')->substitute('/', '@', 'g')
+
+		session.Session.Save(dir, sessionName, attr.mods.silent)
 	})
 
 Command.new('SessionLoad')
@@ -50,8 +61,20 @@ Command.new('SessionLoad')
 			return
 		endif
 
+		if exists_compiled('+shellslash')
+			def Recover(saved: any)
+				&shellslash = saved
+			enddef
+
+			defer Recover(&shellslash)
+			&shellslash = true
+		endif
+
 		var dir = get(g:, "session_dir", "")
-		session.Session.Load(dir, attr.args, attr.mods.silent)
+		var sname = attr.args ?? getcwd()
+
+		sname = sname->substitute('\v(^[A-Z]):', '\1@', '')->substitute('/', '@', 'g')
+		session.Session.Load(dir, sname, attr.mods.silent)
 	})
 
 
@@ -65,4 +88,4 @@ Autocmd.new('VimEnter')
 	.When((): bool => exists('g:session_auto_load'))
 	.Group(group)
 	.Once()
-	.Command('if argc() == 0 && v:argv->len() == 1 | SessionLoad | endif')
+	.Command('if argc() == 0 && v:argv->len() == 1 | silent SessionLoad | endif')


### PR DESCRIPTION
Fixed an issue where session.vim could not distinguish between sessions with the same subdirectory name.